### PR TITLE
refactor: use `useSyncExternalStore`

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "@types/node": "^18.0.3",
     "@types/react": "^18.0.15",
     "@types/react-dom": "^18.0.6",
-    "@types/use-sync-external-store": "^0.0.6",
     "@typescript-eslint/eslint-plugin": "^5.27.1",
     "@typescript-eslint/parser": "^5.27.1",
     "c8": "^7.12.0",
@@ -74,7 +73,5 @@
       ]
     }
   },
-  "dependencies": {
-    "use-sync-external-store": "^1.2.2"
-  }
+  "packageManager": "pnpm@8.15.8+sha256.691fe176eea9a8a80df20e4976f3dfb44a04841ceb885638fe2a26174f81e65e"
 }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@types/node": "^18.0.3",
     "@types/react": "^18.0.15",
     "@types/react-dom": "^18.0.6",
+    "@types/use-sync-external-store": "^0.0.6",
     "@typescript-eslint/eslint-plugin": "^5.27.1",
     "@typescript-eslint/parser": "^5.27.1",
     "c8": "^7.12.0",
@@ -72,5 +73,8 @@
         "@babel/core"
       ]
     }
+  },
+  "dependencies": {
+    "use-sync-external-store": "^1.2.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,11 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-dependencies:
-  use-sync-external-store:
-    specifier: ^1.2.2
-    version: 1.2.2(react@18.2.0)
-
 devDependencies:
   '@testing-library/react':
     specifier: ^13.4.0
@@ -22,9 +17,6 @@ devDependencies:
   '@types/react-dom':
     specifier: ^18.0.6
     version: 18.2.7
-  '@types/use-sync-external-store':
-    specifier: ^0.0.6
-    version: 0.0.6
   '@typescript-eslint/eslint-plugin':
     specifier: ^5.27.1
     version: 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.47.0)(typescript@4.9.5)
@@ -333,10 +325,6 @@ packages:
 
   /@types/semver@7.5.0:
     resolution: {integrity: sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==}
-    dev: true
-
-  /@types/use-sync-external-store@0.0.6:
-    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
     dev: true
 
   /@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.47.0)(typescript@4.9.5):
@@ -2114,6 +2102,7 @@ packages:
 
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+    dev: true
 
   /js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
@@ -2275,6 +2264,7 @@ packages:
     hasBin: true
     dependencies:
       js-tokens: 4.0.0
+    dev: true
 
   /loupe@2.3.6:
     resolution: {integrity: sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==}
@@ -2747,6 +2737,7 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       loose-envify: 1.4.0
+    dev: true
 
   /read-pkg-up@3.0.0:
     resolution: {integrity: sha512-YFzFrVvpC6frF1sz8psoHDBGF7fLPc+llq/8NB43oagqWkx8ar5zYtsTORtOjw9W2RHLpWP+zTWwBvf1bCmcSw==}
@@ -3286,14 +3277,6 @@ packages:
       querystringify: 2.2.0
       requires-port: 1.0.0
     dev: true
-
-  /use-sync-external-store@1.2.2(react@18.2.0):
-    resolution: {integrity: sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    dependencies:
-      react: 18.2.0
-    dev: false
 
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+dependencies:
+  use-sync-external-store:
+    specifier: ^1.2.2
+    version: 1.2.2(react@18.2.0)
+
 devDependencies:
   '@testing-library/react':
     specifier: ^13.4.0
@@ -17,6 +22,9 @@ devDependencies:
   '@types/react-dom':
     specifier: ^18.0.6
     version: 18.2.7
+  '@types/use-sync-external-store':
+    specifier: ^0.0.6
+    version: 0.0.6
   '@typescript-eslint/eslint-plugin':
     specifier: ^5.27.1
     version: 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.47.0)(typescript@4.9.5)
@@ -325,6 +333,10 @@ packages:
 
   /@types/semver@7.5.0:
     resolution: {integrity: sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==}
+    dev: true
+
+  /@types/use-sync-external-store@0.0.6:
+    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
     dev: true
 
   /@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.47.0)(typescript@4.9.5):
@@ -2102,7 +2114,6 @@ packages:
 
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-    dev: true
 
   /js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
@@ -2264,7 +2275,6 @@ packages:
     hasBin: true
     dependencies:
       js-tokens: 4.0.0
-    dev: true
 
   /loupe@2.3.6:
     resolution: {integrity: sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==}
@@ -2737,7 +2747,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       loose-envify: 1.4.0
-    dev: true
 
   /read-pkg-up@3.0.0:
     resolution: {integrity: sha512-YFzFrVvpC6frF1sz8psoHDBGF7fLPc+llq/8NB43oagqWkx8ar5zYtsTORtOjw9W2RHLpWP+zTWwBvf1bCmcSw==}
@@ -3277,6 +3286,14 @@ packages:
       querystringify: 2.2.0
       requires-port: 1.0.0
     dev: true
+
+  /use-sync-external-store@1.2.2(react@18.2.0):
+    resolution: {integrity: sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      react: 18.2.0
+    dev: false
 
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}

--- a/src/use-val.ts
+++ b/src/use-val.ts
@@ -47,6 +47,15 @@ type ValueSnapshot<TValue> = Readonly<[value: TValue, $version: any]>;
 
 const noop = () => void 0;
 
+// useValWithUseSyncExternalStore's implementation is heavily inspired by the
+// useSyncExternalStoreWithSelector from the React Team.
+//
+// https://github.com/facebook/react/blob/0fc9c84e63622026b5977557900c9cfe204552d3/packages/use-sync-external-store/src/useSyncExternalStoreWithSelector.js#L19
+//
+// Differences:
+// - we store [value, $version] instead of full store as snapshot
+// - we compare both value and $version instead of custom isEqual function
+// - we always use value instead of custom selector
 const useValWithUseSyncExternalStore: UseVal = <TValue>(
   val$?: ReadonlyVal<TValue>,
   eager = true
@@ -79,7 +88,8 @@ const useValWithUseSyncExternalStore: UseVal = <TValue>(
    * instance of the useMemo hook.
    *
    * Intentionally not using a useRef hook to track the previously rendered state,
-   * because the ref would be shared across all concurrent copies of the hook/component.
+   * because the ref would be shared across all concurrent copies of the hook/component,
+   * but the useMemo
    *
    * The same approach is also used by the React's official useSyncExternalStoreWithSelector
    */

--- a/src/use-val.ts
+++ b/src/use-val.ts
@@ -1,7 +1,6 @@
 import { type ReadonlyVal } from "value-enhancer";
 
 import reactExports, {
-  useCallback,
   useDebugValue,
   useEffect,
   useMemo,

--- a/src/use-val.ts
+++ b/src/use-val.ts
@@ -98,7 +98,6 @@ const useValWithUseSyncExternalStore: UseVal = <TValue>(
       ? () => [val$.get(), val$.$version]
       : noop;
 
-    let hasMemo = false;
     let memoizedSnapshot: ValueSnapshot<TValue> | undefined = void 0;
 
     const memoizedSelector = (
@@ -107,33 +106,15 @@ const useValWithUseSyncExternalStore: UseVal = <TValue>(
       if (nextSnapshot === void 0) {
         // The nextSnapshot can only be undefined if the $val is missing (valueGetter is noop)
         // let's clear internal memoized state and return undefined
-        hasMemo = false;
         memoizedSnapshot = void 0;
         return void 0;
-      }
-
-      if (!hasMemo) {
-        // The first time the hook is called, there is no memoized result.
-        // We can return the incoming value directly without any comparison.
-        hasMemo = true;
-        memoizedSnapshot = nextSnapshot;
-
-        /**
-         * TODO: if incoming $val itself has changed (from one reactive value to another),
-         * this useMemo instance will be re-created and all internally tracked memoized
-         * state will be lost.
-         *
-         * But if new $val and the previous $val has the same value and version,
-         * should we bail out re-render or not?
-         */
-
-        return nextSnapshot[0];
       }
 
       if (memoizedSnapshot === void 0) {
         /**
          * If the previous snapshot is undefined but next snapshot is not,
-         * it means that previously no $val is given, but now it is.
+         * it means that either this is the first time the hook is called,
+         * or previously no $val is given, but now it is.
          *
          * So we need to signal to React that the value has changed and a re-render
          * should be scheduled.

--- a/src/use-val.ts
+++ b/src/use-val.ts
@@ -40,15 +40,6 @@ interface UseVal {
  */
 type Subscriber = Parameters<(typeof reactExports)["useSyncExternalStore"]>[0];
 
-// useValWithUseSyncExternalStore's implementation is heavily inspired by the
-// useSyncExternalStoreWithSelector from the React Team.
-//
-// https://github.com/facebook/react/blob/0fc9c84e63622026b5977557900c9cfe204552d3/packages/use-sync-external-store/src/useSyncExternalStoreWithSelector.js#L19
-//
-// Differences:
-// - we store [value, $version] instead of full store as snapshot
-// - we compare both value and $version instead of custom isEqual function
-// - we always use value instead of custom selector
 export const useValWithUseSyncExternalStore: UseVal = <TValue>(
   val$?: ReadonlyVal<TValue>,
   eager = true

--- a/src/use-val.ts
+++ b/src/use-val.ts
@@ -1,40 +1,56 @@
 import { type ReadonlyVal } from "value-enhancer";
 
-import { useCallback, useDebugValue } from "react";
-import { useSyncExternalStore } from "use-sync-external-store";
+import reactExports, {
+  useCallback,
+  useDebugValue,
+  useEffect,
+  useMemo,
+  useState,
+  useSyncExternalStore,
+} from "react";
 
-type Subscriber = Parameters<typeof useSyncExternalStore>[0];
+// Function overload with TypeScript interface
+interface UseVal {
+  /**
+   * Accepts a val from anywhere and returns the latest value.
+   * It only triggers re-rendering when new value emitted from val (base on val `equal` not `Object.is` comparison from React `useState`).
+   *
+   * @param val$ A val of value
+   * @param eager Trigger subscription callback synchronously. Default true.
+   * @returns the value
+   */
+  <TValue>(val$: ReadonlyVal<TValue>, eager?: boolean): TValue;
+
+  /**
+   * Accepts a val from anywhere and returns the latest value.
+   * It only triggers re-rendering when new value emitted from val (base on val `equal` not `Object.is` comparison from React `useState`).
+   *
+   * @param val$ A val of value
+   * @param eager Trigger subscription callback synchronously. Default true.
+   * @returns the value, or undefined if val is undefined
+   */
+  <TValue = any>(val$?: ReadonlyVal<TValue>, eager?: boolean):
+    | TValue
+    | undefined;
+}
+
+// Utility types and functions for useValWithUseSyncExternalStore
+
+/**
+ * The subscriber function that is passed to useSyncExternalStore hook.
+ */
+type Subscriber = Parameters<(typeof reactExports)["useSyncExternalStore"]>[0];
+/**
+ * The snapshot that holds both the real value and the version of the reactive value.
+ */
+type ValueSnapshot<TValue> = Readonly<[value: TValue, $version: any]>;
 
 const noop = () => void 0;
 
-/**
- * Accepts a val from anywhere and returns the latest value.
- * It only triggers re-rendering when new value emitted from val (base on val `equal` not `Object.is` comparison from React `useState`).
- *
- * @param val$ A val of value
- * @param eager Trigger subscription callback synchronously. Default true.
- * @returns the value
- */
-export function useVal<TValue = any>(
-  val$: ReadonlyVal<TValue>,
-  eager?: boolean
-): TValue;
-/**
- * Accepts a val from anywhere and returns the latest value.
- * It only triggers re-rendering when new value emitted from val (base on val `equal` not `Object.is` comparison from React `useState`).
- *
- * @param val$ A val of value
- * @param eager Trigger subscription callback synchronously. Default true.
- * @returns the value, or undefined if val is undefined
- */
-export function useVal<TValue = any>(
-  val$?: ReadonlyVal<TValue>,
-  eager?: boolean
-): TValue | undefined;
-export function useVal<TValue = any>(
+const useValWithUseSyncExternalStore: UseVal = <TValue>(
   val$?: ReadonlyVal<TValue>,
   eager = true
-): TValue | undefined {
+): TValue | undefined => {
   const subscriber = useCallback<Subscriber>(
     onStoreChange => {
       if (val$) return val$.subscribe(onStoreChange, eager);
@@ -43,17 +59,146 @@ export function useVal<TValue = any>(
     [val$, eager]
   );
 
-  const valueGetter = val$ ? val$.get : noop;
+  const isEqual = (
+    prevSnapshot: ValueSnapshot<TValue>,
+    nextSnapshot: ValueSnapshot<TValue>
+  ) => {
+    const prevValue = prevSnapshot[0];
+    const nextValue = nextSnapshot[0];
+
+    const prevVersion = prevSnapshot[1];
+    const nextVersion = nextSnapshot[1];
+
+    return (
+      Object.is(prevVersion, nextVersion) && Object.is(prevValue, nextValue)
+    );
+  };
+
+  /**
+   * Track the memoized state using closure variables that are local to this
+   * instance of the useMemo hook.
+   *
+   * Intentionally not using a useRef hook to track the previously rendered state,
+   * because the ref would be shared across all concurrent copies of the hook/component.
+   *
+   * The same approach is also used by the React's official useSyncExternalStoreWithSelector
+   */
+  const getSnapshot = useMemo(() => {
+    const valueGetter: () => ValueSnapshot<TValue> | undefined = val$
+      ? () => [val$.get(), val$.$version]
+      : noop;
+
+    let hasMemo = false;
+    let memoizedSnapshot: ValueSnapshot<TValue> | undefined = void 0;
+
+    const memoizedSelector = (
+      nextSnapshot: ValueSnapshot<TValue> | undefined
+    ) => {
+      if (nextSnapshot === void 0) {
+        // The nextSnapshot can only be undefined if the $val is missing (valueGetter is noop)
+        // let's clear internal memoized state and return undefined
+        hasMemo = false;
+        memoizedSnapshot = void 0;
+        return void 0;
+      }
+
+      if (!hasMemo) {
+        // The first time the hook is called, there is no memoized result.
+        // We can return the incoming value directly without any comparison.
+        hasMemo = true;
+        memoizedSnapshot = nextSnapshot;
+
+        /**
+         * TODO: if incoming $val itself has changed (from one reactive value to another),
+         * this useMemo instance will be re-created and all internally tracked memoized
+         * state will be lost.
+         *
+         * But if new $val and the previous $val has the same value and version,
+         * should we bail out re-render or not?
+         */
+
+        return nextSnapshot[0];
+      }
+
+      if (memoizedSnapshot === void 0) {
+        /**
+         * If the previous snapshot is undefined but next snapshot is not,
+         * it means that previously no $val is given, but now it is.
+         *
+         * So we need to signal to React that the value has changed and a re-render
+         * should be scheduled.
+         */
+        memoizedSnapshot = nextSnapshot;
+        return /** nextValue */ nextSnapshot[0];
+      }
+
+      /**
+       * Previously $val is already given and its snapshot is stored,
+       * now the
+       */
+
+      // Only if both the version and the value are the same, we can bail out
+      // the re-render.
+      // We bail out the re-render by returning the previous value, which signals
+      // to React that the value are conceptually equal
+      if (isEqual(memoizedSnapshot, nextSnapshot)) {
+        return /** prevValue */ memoizedSnapshot[0];
+      }
+
+      // If either the version or the value has changed, we update the stored
+      // the current snapshot for the next invocation and comparison
+      memoizedSnapshot = nextSnapshot;
+
+      // We return the next value to signal to React that the value has changed
+      // and a re-render should be scheduled
+      const nextValue = nextSnapshot[0];
+
+      return nextValue;
+    };
+
+    return () => memoizedSelector(valueGetter());
+  }, [val$]);
 
   const value = useSyncExternalStore(
     subscriber,
-    valueGetter,
+    getSnapshot,
     // It is safe to use the same value getter for server snapshot since val() can
     // be initialized with a default value.
-    valueGetter
+    getSnapshot
   );
 
   useDebugValue(value);
 
   return value;
-}
+};
+
+const useValWithUseEffect: UseVal = <TValue>(
+  val$?: ReadonlyVal<TValue>,
+  eager = true
+): TValue | undefined => {
+  const [value, setValue] = useState(val$ ? val$.get : void 0);
+  const [, setVersion] = useState(val$?.$version);
+
+  useEffect(() => {
+    if (val$) {
+      const versionSetter = () => val$.$version;
+      const updateValue = () => {
+        setVersion(versionSetter);
+        setValue(val$.get);
+      };
+      return val$.subscribe(updateValue, eager);
+    } else {
+      setVersion(void 0);
+      setValue(void 0);
+    }
+  }, [val$, eager]);
+
+  useDebugValue(value);
+
+  return value;
+};
+
+// @ts-expect-error -- useSyncExternalStore is not available in React 16 & 17
+export const useVal: UseVal = reactExports.useSyncExternalStore
+  ? useValWithUseSyncExternalStore
+  : useValWithUseEffect;

--- a/src/use-val.ts
+++ b/src/use-val.ts
@@ -6,7 +6,6 @@ import reactExports, {
   useEffect,
   useMemo,
   useState,
-  useSyncExternalStore,
 } from "react";
 
 // Function overload with TypeScript interface
@@ -40,12 +39,6 @@ interface UseVal {
  * The subscriber function that is passed to useSyncExternalStore hook.
  */
 type Subscriber = Parameters<(typeof reactExports)["useSyncExternalStore"]>[0];
-/**
- * The snapshot that holds both the real value and the version of the reactive value.
- */
-type ValueSnapshot<TValue> = Readonly<[value: TValue, $version: any]>;
-
-const noop = () => void 0;
 
 // useValWithUseSyncExternalStore's implementation is heavily inspired by the
 // useSyncExternalStoreWithSelector from the React Team.
@@ -56,101 +49,20 @@ const noop = () => void 0;
 // - we store [value, $version] instead of full store as snapshot
 // - we compare both value and $version instead of custom isEqual function
 // - we always use value instead of custom selector
-const useValWithUseSyncExternalStore: UseVal = <TValue>(
+export const useValWithUseSyncExternalStore: UseVal = <TValue>(
   val$?: ReadonlyVal<TValue>,
   eager = true
 ): TValue | undefined => {
-  const subscriber = useCallback<Subscriber>(
-    onStoreChange => {
-      if (val$) return val$.subscribe(onStoreChange, eager);
-      return noop;
-    },
+  const [subscriber, getSnapshot] = useMemo(
+    () =>
+      [
+        (onStoreChange => val$?.subscribe(onStoreChange, eager)) as Subscriber,
+        () => val$?.$version,
+      ] as const,
     [val$, eager]
   );
 
-  const isEqual = (
-    prevSnapshot: ValueSnapshot<TValue>,
-    nextSnapshot: ValueSnapshot<TValue>
-  ) => {
-    const prevValue = prevSnapshot[0];
-    const nextValue = nextSnapshot[0];
-
-    const prevVersion = prevSnapshot[1];
-    const nextVersion = nextSnapshot[1];
-
-    return (
-      Object.is(prevVersion, nextVersion) && Object.is(prevValue, nextValue)
-    );
-  };
-
-  /**
-   * Track the memoized state using closure variables that are local to this
-   * instance of the useMemo hook.
-   *
-   * Intentionally not using a useRef hook to track the previously rendered state,
-   * because the ref would be shared across all concurrent copies of the hook/component,
-   * but the useMemo
-   *
-   * The same approach is also used by the React's official useSyncExternalStoreWithSelector
-   */
-  const getSnapshot = useMemo(() => {
-    const valueGetter: () => ValueSnapshot<TValue> | undefined = val$
-      ? () => [val$.get(), val$.$version]
-      : noop;
-
-    let memoizedSnapshot: ValueSnapshot<TValue> | undefined = void 0;
-
-    const memoizedSelector = (
-      nextSnapshot: ValueSnapshot<TValue> | undefined
-    ) => {
-      if (nextSnapshot === void 0) {
-        // The nextSnapshot can only be undefined if the $val is missing (valueGetter is noop)
-        // let's clear internal memoized state and return undefined
-        memoizedSnapshot = void 0;
-        return void 0;
-      }
-
-      if (memoizedSnapshot === void 0) {
-        /**
-         * If the previous snapshot is undefined but next snapshot is not,
-         * it means that either this is the first time the hook is called,
-         * or previously no $val is given, but now it is.
-         *
-         * So we need to signal to React that the value has changed and a re-render
-         * should be scheduled.
-         */
-        memoizedSnapshot = nextSnapshot;
-        return /** nextValue */ nextSnapshot[0];
-      }
-
-      /**
-       * Previously $val is already given and its snapshot is stored,
-       * now the
-       */
-
-      // Only if both the version and the value are the same, we can bail out
-      // the re-render.
-      // We bail out the re-render by returning the previous value, which signals
-      // to React that the value are conceptually equal
-      if (isEqual(memoizedSnapshot, nextSnapshot)) {
-        return /** prevValue */ memoizedSnapshot[0];
-      }
-
-      // If either the version or the value has changed, we update the stored
-      // the current snapshot for the next invocation and comparison
-      memoizedSnapshot = nextSnapshot;
-
-      // We return the next value to signal to React that the value has changed
-      // and a re-render should be scheduled
-      const nextValue = nextSnapshot[0];
-
-      return nextValue;
-    };
-
-    return () => memoizedSelector(valueGetter());
-  }, [val$]);
-
-  const value = useSyncExternalStore(
+  reactExports.useSyncExternalStore(
     subscriber,
     getSnapshot,
     // It is safe to use the same value getter for server snapshot since val() can
@@ -158,12 +70,12 @@ const useValWithUseSyncExternalStore: UseVal = <TValue>(
     getSnapshot
   );
 
-  useDebugValue(value);
+  useDebugValue(val$?.value);
 
-  return value;
+  return val$?.value;
 };
 
-const useValWithUseEffect: UseVal = <TValue>(
+export const useValWithUseEffect: UseVal = <TValue>(
   val$?: ReadonlyVal<TValue>,
   eager = true
 ): TValue | undefined => {
@@ -189,7 +101,10 @@ const useValWithUseEffect: UseVal = <TValue>(
   return value;
 };
 
-// @ts-expect-error -- useSyncExternalStore is not available in React 16 & 17
-export const useVal: UseVal = reactExports.useSyncExternalStore
-  ? useValWithUseSyncExternalStore
-  : useValWithUseEffect;
+/* c8 ignore start */
+export const useVal: UseVal = /* @__PURE__ */ (() =>
+  // @ts-expect-error -- useSyncExternalStore is not available in React 16 & 17
+  reactExports.useSyncExternalStore
+    ? useValWithUseSyncExternalStore
+    : useValWithUseEffect)();
+/* c8 ignore stop */

--- a/test/use-val.test.ts
+++ b/test/use-val.test.ts
@@ -56,7 +56,7 @@ describe("useVal", () => {
 
     it("undefined -> val$", () => {
       const { result: result1 } = renderHook(() => useVal());
-      expect(result1.current).toBeUndefined;
+      expect(result1.current).toBeUndefined();
 
       const val$ = val(1);
       const { result: result2 } = renderHook(() => useVal(val$));

--- a/test/use-val.test.ts
+++ b/test/use-val.test.ts
@@ -62,6 +62,16 @@ describe("useVal", () => {
       const { result: result2 } = renderHook(() => useVal(val$));
       expect(result2.current).toBe(1);
     });
+
+    it("val1$ -> val2$", () => {
+      const val1$ = val(1);
+      const { result: result1 } = renderHook(() => useVal(val1$));
+      expect(result1.current).toBe(1);
+
+      const val2$ = val(2);
+      const { result: result2 } = renderHook(() => useVal(val2$));
+      expect(result2.current).toBe(2);
+    });
   });
 
   it("should trigger re-render after reactive collections has changed", async () => {

--- a/test/use-val.test.ts
+++ b/test/use-val.test.ts
@@ -44,6 +44,26 @@ describe("useVal", () => {
     expect(result.current).not.toBe(fn);
   });
 
+  it("should get correct value after val$ changes", async () => {
+    it("val$ -> undefined", () => {
+      const val$ = val(1);
+      const { result: result1 } = renderHook(() => useVal(val$));
+      expect(result1.current).toBe(1);
+
+      const { result: result2 } = renderHook(() => useVal());
+      expect(result2.current).toBeUndefined();
+    });
+
+    it("undefined -> val$", () => {
+      const { result: result1 } = renderHook(() => useVal());
+      expect(result1.current).toBeUndefined;
+
+      const val$ = val(1);
+      const { result: result2 } = renderHook(() => useVal(val$));
+      expect(result2.current).toBe(1);
+    });
+  });
+
   it("should not trigger extra rendering on initial value", async () => {
     const val$ = val(1);
     let renderingCount = 0;

--- a/test/use-val.test.ts
+++ b/test/use-val.test.ts
@@ -1,11 +1,28 @@
 import { renderHook, act } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 import { derive, val, nextTick } from "value-enhancer";
-import { useVal } from "../src/index";
+import {
+  useVal,
+  useValWithUseEffect,
+  useValWithUseSyncExternalStore,
+} from "../src/index";
 import type { ReactiveMap } from "value-enhancer/collections";
 import { reactiveMap } from "value-enhancer/collections";
 
-describe("useVal", () => {
+describe.each([
+  {
+    name: "useVal",
+    useVal,
+  },
+  {
+    name: "useValWithUseEffect",
+    useVal: useValWithUseEffect,
+  },
+  {
+    name: "useValWithUseSyncExternalStore",
+    useVal: useValWithUseSyncExternalStore,
+  },
+])("useVal ($a)", ({ useVal }) => {
   it("should get value from val", () => {
     const val$ = val(1);
     const { result } = renderHook(() => useVal(val$));

--- a/test/use-val.test.ts
+++ b/test/use-val.test.ts
@@ -64,6 +64,27 @@ describe("useVal", () => {
     });
   });
 
+  it("should trigger re-render after reactive collections has changed", async () => {
+    const map$ = reactiveMap<string, number>();
+    map$.set("foo", 1);
+
+    const { result: result1 } = renderHook(() => {
+      const map = useVal(map$.$);
+      return map.get("foo");
+    });
+
+    expect(result1.current).toEqual(1);
+
+    await act(async () => map$.set("foo", 2));
+    const { result: result2 } = renderHook(() => {
+      const map = useVal(map$.$);
+      return map.get("foo");
+    });
+
+    expect(result2.current).toEqual(2);
+    map$.dispose();
+  });
+
   it("should not trigger extra rendering on initial value", async () => {
     const val$ = val(1);
     let renderingCount = 0;


### PR DESCRIPTION
The PR changes `useVal`'s implementation to use `useSyncExternalStore` introduced in React 18.

To be backward compatible with React 16 and React 17, a package `use-sync-external-store` (published by the React Team as a polyfill) is also introduced.

All test cases pass on my machine locally.

## Additional Context

**What is `useSyncExternalStore`?**

- https://github.com/reactwg/react-18/discussions/70
- https://github.com/reactwg/react-18/discussions/86

In short, with the new `useSyncExternalStore` hook, maintainers of state management libraries no longer need to use `forceUpdate`/`setState`. Instead, React can now subscribe to the external store, track its updates, and schedule a re-render with the newest value to avoid in-consistent UI being committed to the DOM.

See also:

- https://github.com/nanostores/react/issues/6
- https://github.com/nanostores/react/pull/7