### PR TITLE
ci: pnpm setup auto version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,9 +19,8 @@ jobs:
             ${{ runner.os }}-
 
       - name: Install pnpm 🤏🏻
-        uses: pnpm/action-setup@v2.1.0
+        uses: pnpm/action-setup@v4.0.0
         with:
-          version: latest
           run_install: true
 
       - name: Build 🔧


### PR DESCRIPTION
Previously, `pnpm/action-setup` was configured to use the latest version of pnpm (which was 9.1.0 for now).

In my last PR, I designated a specific version of pnpm (8.15.8).

This PR fixes the CI by updating the `pnpm/action-setup` which supports the automatic reading of the `packageManager` field from the `package.json` file.